### PR TITLE
Improve list item normalization

### DIFF
--- a/packages/editure/src/plugins/list.ts
+++ b/packages/editure/src/plugins/list.ts
@@ -130,7 +130,7 @@ export const withList = (editor: EditorWithBlock) => {
     if (node.type === BULLETED_LIST) {
       for (const [child, childPath] of Node.children(e, path)) {
         const { level = 0, children = [] } = child;
-        Transforms.setNodes(e, { level, parent: node.type }, { at: childPath });
+        Transforms.setNodes(e, { type: LIST_ITEM, level, parent: node.type }, { at: childPath });
 
         // List item should not have any block child.
         if (children.length === 1 && Element.isElement(children[0])) {


### PR DESCRIPTION
Before:

![previous-listitem](https://user-images.githubusercontent.com/23410977/79442176-c6b4fe00-800a-11ea-90db-7b9bf11f16f7.gif)

After:

![after-listitem](https://user-images.githubusercontent.com/23410977/79442189-ca488500-800a-11ea-94b2-6b7b3f6989e7.gif)
